### PR TITLE
[fix] Placeholder text

### DIFF
--- a/Sources/iPhoneNumberField/iPhoneNumberField.swift
+++ b/Sources/iPhoneNumberField/iPhoneNumberField.swift
@@ -175,7 +175,13 @@ public struct iPhoneNumberField: UIViewRepresentable {
         uiView.withFlag = showFlag
         uiView.withDefaultPickerUI = selectableFlag
         uiView.withPrefix = previewPrefix
-        uiView.withExamplePlaceholder = autofillPrefix || placeholder == nil
+
+        if placeholder != nil {
+            uiView.placeholder = placeholder
+        } else {
+            uiView.withExamplePlaceholder = autofillPrefix
+        }
+
         if autofillPrefix { uiView.resignFirstResponder() } // Workaround touch autofill issue
         uiView.tintColor = accentColor
         


### PR DESCRIPTION
Quick fix for the issue raised in #22. Looks like`withExamplePlaceholder` overwrites the placeholder when called after the placeholder is initially set. I don't know if I'd qualify this as a true fix, but it definitely gets the job done for scenarios both with and without placeholder text.