### PR TITLE
Autofill fix with placeholder text fix

### DIFF
--- a/Sources/iPhoneNumberField/iPhoneNumberField+ViewModifiers.swift
+++ b/Sources/iPhoneNumberField/iPhoneNumberField+ViewModifiers.swift
@@ -381,6 +381,6 @@ public extension iPhoneNumberField {
     /// Our packages inherently voids the functionality of textContentType 🙃. As described by Apple 👩‍💻, "The textContentType property is designed to provide the keyboard with extra information about the semantic intent of the text document". However, in `iPhoneNumberField`'s case the semantic intent is always to write a phone number 😁☎
     /// - Parameter textContentType:
     /// - Returns: self
-    @available(*, deprecated, message: "Our packages inherently voids the functionality of textContentType 🙃")
-    func textContentType(_ textContentType: UITextContentType?) -> some View { return self }
+//    @available(*, deprecated, message: "Our packages inherently voids the functionality of textContentType 🙃")
+//    func textContentType(_ textContentType: UITextContentType?) -> some View { return self }
 }

--- a/Sources/iPhoneNumberField/iPhoneNumberField.swift
+++ b/Sources/iPhoneNumberField/iPhoneNumberField.swift
@@ -164,7 +164,7 @@ public struct iPhoneNumberField: UIViewRepresentable {
 
     public func updateUIView(_ uiView: PhoneNumberTextField, context: UIViewRepresentableContext<Self>) {
         configuration(uiView)
-        
+        uiView.textContentType = .telephoneNumber //allow auto-fill to work with telephone text field
         uiView.text = displayedText
         uiView.font = font
         uiView.maxDigits = maxDigits
@@ -175,7 +175,12 @@ public struct iPhoneNumberField: UIViewRepresentable {
         uiView.withFlag = showFlag
         uiView.withDefaultPickerUI = selectableFlag
         uiView.withPrefix = previewPrefix
-        uiView.withExamplePlaceholder = autofillPrefix || placeholder == nil
+        //uiView.withExamplePlaceholder = autofillPrefix || placeholder == nil
+        if placeholder != nil {
+            uiView.placeholder = placeholder
+        } else {
+            uiView.withExamplePlaceholder = autofillPrefix
+        }
         if autofillPrefix { uiView.resignFirstResponder() } // Workaround touch autofill issue
         uiView.tintColor = accentColor
         


### PR DESCRIPTION
If you would like to use autofill (iOS keyboard auto-fill support) with iPhoneNumberField, this adds that support for the phone number text content type.

Also includes fix from  @brandtdaniels and @dns-mcdaid for placeholder text.