### PR TITLE
Fix infinite change loop

### DIFF
--- a/Sources/iPhoneNumberField/iPhoneNumberField.swift
+++ b/Sources/iPhoneNumberField/iPhoneNumberField.swift
@@ -180,7 +180,7 @@ public struct iPhoneNumberField: UIViewRepresentable {
         } else {
             uiView.withExamplePlaceholder = autofillPrefix
         }
-        if autofillPrefix { uiView.resignFirstResponder() } // Workaround touch autofill issue
+        if autofillPrefix && displayedText.isEmpty && isFirstResponder { uiView.resignFirstResponder() } // Workaround touch autofill issue
         uiView.tintColor = accentColor
         
         if let defaultRegion = defaultRegion {


### PR DESCRIPTION
After PhoneNumberTextField sets it's text to a country code, the iPhoneNumberField's textFieldDidEndEditing may start an infinite updateUIView loop that coul lead to a watchdog to kill an app.
Only call resignFirstResponder in case of empty text, so that the next updateUIView call won't call it again.

fixes #45