### PR TITLE
Fixed iOS 16 graph cycle error

### DIFF
--- a/MultiplatformDemo/MultiplatformDemo.xcodeproj/project.pbxproj
+++ b/MultiplatformDemo/MultiplatformDemo.xcodeproj/project.pbxproj
@@ -288,7 +288,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MultiplatformDemo/Preview Content\"";
-				DEVELOPMENT_TEAM = K4KFSHFA37;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -325,7 +324,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MultiplatformDemo/Preview Content\"";
-				DEVELOPMENT_TEAM = K4KFSHFA37;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;

--- a/MultiplatformDemo/MultiplatformDemo.xcodeproj/project.pbxproj
+++ b/MultiplatformDemo/MultiplatformDemo.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MultiplatformDemo/Preview Content\"";
+				DEVELOPMENT_TEAM = K4KFSHFA37;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -324,6 +325,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MultiplatformDemo/Preview Content\"";
+				DEVELOPMENT_TEAM = K4KFSHFA37;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/marmelroy/PhoneNumberKit",
         "state": {
           "branch": null,
-          "revision": "c7d7b0c91ef0ad7e413022edfcf5d6f75561e2d5",
-          "version": "3.3.1"
+          "revision": "b2c695c9aedc70edd8494e3ed0902a0817e57e41",
+          "version": "3.5.3"
         }
       }
     ]

--- a/Sources/iPhoneNumberField/iPhoneNumberField.swift
+++ b/Sources/iPhoneNumberField/iPhoneNumberField.swift
@@ -179,7 +179,7 @@ public struct iPhoneNumberField: UIViewRepresentable {
         } else {
             uiView.withExamplePlaceholder = autofillPrefix
         }
-        if autofillPrefix && displayedText.isEmpty && isFirstResponder { uiView.resignFirstResponder() } // Workaround touch autofill issue
+        
         uiView.tintColor = accentColor
         
         if let numberPlaceholderColor = numberPlaceholderColor {
@@ -192,10 +192,12 @@ public struct iPhoneNumberField: UIViewRepresentable {
             uiView.textAlignment = textAlignment
         }
 
-        if isFirstResponder {
-            uiView.becomeFirstResponder()
-        } else {
-            uiView.resignFirstResponder()
+        DispatchQueue.main.async {
+            if isFirstResponder {
+                uiView.becomeFirstResponder()
+            } else {
+                uiView.resignFirstResponder()
+            }
         }
         
         configuration(uiView)


### PR DESCRIPTION
Example of the code that triggered cycle errors & strange keyboard behaviour:
```
iPhoneNumberField(text: $text)
    .flagHidden(true)
    .prefixHidden(false)
    .autofillPrefix(true)
```
I fixed the issue in this commit.