### PR TITLE
Enhancement: Added Insets Support.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     {
       "identity" : "phonenumberkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MussaCharles/PhoneNumberKit",
+      "location" : "https://github.com/marmelroy/PhoneNumberKit",
       "state" : {
-        "revision" : "c474ff7aec5093f956d3cdc33082dd9e5d497782",
-        "version" : "0.1.0"
+        "revision" : "9bc965a326df8d5115f0b7bb77f09c542b8ec417",
+        "version" : "3.6.6"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "PhoneNumberKit",
-        "repositoryURL": "https://github.com/marmelroy/PhoneNumberKit",
-        "state": {
-          "branch": null,
-          "revision": "c7d7b0c91ef0ad7e413022edfcf5d6f75561e2d5",
-          "version": "3.3.1"
-        }
+  "pins" : [
+    {
+      "identity" : "phonenumberkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MussaCharles/PhoneNumberKit",
+      "state" : {
+        "revision" : "c474ff7aec5093f956d3cdc33082dd9e5d497782",
+        "version" : "0.1.0"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // TODO: - Uncomment path to the main repo and point to a version where this PR (https://github.com/marmelroy/PhoneNumberKit/pull/669) is merged.
 //        .package(url: "https://github.com/marmelroy/PhoneNumberKit", .upToNextMajor(from: "3.4.5")),
-        .package(url: "https://github.com/MussaCharles/PhoneNumberKit", branch: "charles/feature-textfield-insets")
+        .package(url: "https://github.com/MussaCharles/PhoneNumberKit", from: "0.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -16,7 +16,9 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/marmelroy/PhoneNumberKit", .upToNextMajor(from: "3.4.5"))
+        // TODO: - Uncomment path to the main repo and point to a version where this PR (https://github.com/marmelroy/PhoneNumberKit/pull/669) is merged.
+//        .package(url: "https://github.com/marmelroy/PhoneNumberKit", .upToNextMajor(from: "3.4.5")),
+        .package(url: "https://github.com/MussaCharles/PhoneNumberKit", branch: "charles/feature-textfield-insets")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // TODO: - Uncomment path to the main repo and point to a version where this PR (https://github.com/marmelroy/PhoneNumberKit/pull/669) is merged.
-//        .package(url: "https://github.com/marmelroy/PhoneNumberKit", .upToNextMajor(from: "3.4.5")),
-        .package(url: "https://github.com/MussaCharles/PhoneNumberKit", from: "0.1.0")
+        .package(url: "https://github.com/marmelroy/PhoneNumberKit", from: "3.6.6")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/iPhoneNumberField/iPhoneNumberField.swift
+++ b/Sources/iPhoneNumberField/iPhoneNumberField.swift
@@ -131,23 +131,30 @@ public struct iPhoneNumberField: UIViewRepresentable {
     
     /// Whether the phone number field is enabled for interaction. ✅
     internal var isUserInteractionEnabled = true
-
+    
+    private let insets: UIEdgeInsets
+    private let clearButtonPadding: CGFloat
+    
     public init(_ title: String? = nil,
                 text: Binding<String>,
                 isEditing: Binding<Bool>? = nil,
                 formatted: Bool = true,
+                insets: UIEdgeInsets = .zero,
+                clearButtonPadding: CGFloat = 6,
                 configuration: @escaping (UIViewType) -> () = { _ in } ) {
 
         self.placeholder = title
         self.externalIsFirstResponder = isEditing
         self.formatted = formatted
+        self.insets = insets
+        self.clearButtonPadding = clearButtonPadding
         self._text = text
         self._displayedText = State(initialValue: text.wrappedValue)
         self.configuration = configuration
     }
 
     public func makeUIView(context: UIViewRepresentableContext<Self>) -> PhoneNumberTextField {
-        let uiView = UIViewType()
+        let uiView = UIViewType(insets: insets, clearButtonPadding: clearButtonPadding)
         
         uiView.setContentHuggingPriority(.defaultHigh, for: .vertical)
         uiView.addTarget(context.coordinator,

--- a/Sources/iPhoneNumberField/iPhoneNumberField.swift
+++ b/Sources/iPhoneNumberField/iPhoneNumberField.swift
@@ -186,7 +186,8 @@ public struct iPhoneNumberField: UIViewRepresentable {
         } else {
             uiView.withExamplePlaceholder = autofillPrefix
         }
-        if autofillPrefix && displayedText.isEmpty && isFirstResponder { uiView.resignFirstResponder() } // Workaround touch autofill issue
+        // Temporary commenting to reflect changes on this PR -> https://github.com/MojtabaHs/iPhoneNumberField/pull/76/commits/1a8e24c0a6a0f6f84f89002bd5cb2b39ae9cb06a
+//        if autofillPrefix && displayedText.isEmpty && isFirstResponder { uiView.resignFirstResponder() } // Workaround touch autofill issue
         uiView.tintColor = accentColor
         
         if let numberPlaceholderColor = numberPlaceholderColor {
@@ -199,10 +200,13 @@ public struct iPhoneNumberField: UIViewRepresentable {
             uiView.textAlignment = textAlignment
         }
 
-        if isFirstResponder {
-            uiView.becomeFirstResponder()
-        } else {
-            uiView.resignFirstResponder()
+        // Reflecting: https://github.com/MojtabaHs/iPhoneNumberField/pull/76/commits/1a8e24c0a6a0f6f84f89002bd5cb2b39ae9cb06a
+        DispatchQueue.main.async { 
+            if isFirstResponder {
+                uiView.becomeFirstResponder()
+            } else {
+                uiView.resignFirstResponder()
+            }
         }
         
         configuration(uiView)


### PR DESCRIPTION
I have added support to forward paddings to the internally used `PhoneNumberTextField`. 

To achieve this I had to add paddings support to the official [PhoneNumberTextField](https://github.com/marmelroy/PhoneNumberKit/pull/669) which was recently merged and released with [PhoneNumberKit version 3.6.6](https://github.com/marmelroy/PhoneNumberKit). 

On iPhoneNumberField I have simply added the following two params: - 

```swift
   private let insets: UIEdgeInsets
   private let clearButtonPadding: CGFloat
```

Initilized them with the following default values so that it doesn't break developers code. 

```swift
  public init(
       insets: UIEdgeInsets = .zero,
       clearButtonPadding: CGFloat = 6
      // -- 
    )

```
 and forward them to PhoneNumberKit as follows: - 

```swift
 let uiView = UIViewType(insets: insets, clearButtonPadding: clearButtonPadding)
```

All other implementations details are handled on the latest version of [PhoneNumberKit](https://github.com/marmelroy/PhoneNumberKit) which have my suggested changes [merged via my PR #669](https://github.com/marmelroy/PhoneNumberKit/pull/669). 

Since paddings support are available from version 3.6.6 of PhoneNumberKit I have changed the package dependency version as follows: - 

```swift
// Package.swift
.package(url: "https://github.com/marmelroy/PhoneNumberKit", from: "3.6.6")
```

As an added benefit, I have also increased swift tools version to 5.7
```swift
// Package.swift
swift-tools-version:5.7
```
I'm looking forward to your feedback on this enhancement. I believe it's a valuable addition to the library, making it more versatile for usage in diverse design contexts.
Please the sample below & the attached screenshot below:

```swift
struct MyView: View {

  // MARK: - Properties
 @Binding var directInputText: String
 @Binding var isEditing: Bool
 let placeHolderText: String = "Type something"

// MARK: - Body
var body: some View {
     iPhoneNumberField(
              // -- Other properties,
              insets: UIEdgeInsets(top: 14, left: 16, bottom: 14, right: 16)
            ) {
                $0.textColor = .label
                $0.numberPlaceholderColor = .label
          }
  }

}
```

<img width="429" alt="Screenshot 2023-07-15 at 1 43 12 PM" src="https://github.com/MojtabaHs/iPhoneNumberField/assets/25889447/448a6c95-9528-469a-9c5c-813ebeccc6b7">
