### PR TITLE
Textfield Reverts to Default When Selecting a Different Country

### DIFF
--- a/Sources/iPhoneNumberField/iPhoneNumberField.swift
+++ b/Sources/iPhoneNumberField/iPhoneNumberField.swift
@@ -176,7 +176,11 @@ public struct iPhoneNumberField: UIViewRepresentable {
             uiView.withFlag = showFlag
             uiView.withDefaultPickerUI = selectableFlag
             uiView.withPrefix = previewPrefix
-            uiView.partialFormatter.defaultRegion = defaultRegion ?? PhoneNumberKit.defaultRegionCode()
+            
+            if let defaultRegion {
+                uiView.partialFormatter.defaultRegion = defaultRegion
+            }
+            
             if placeholder != nil {
                 uiView.placeholder = placeholder
             } else {


### PR DESCRIPTION
address https://github.com/MojtabaHs/iPhoneNumberField/issues/105 issue 
according to PhoneNumberKit implementation, there is no need to set default if it does not exist .